### PR TITLE
[spec] Remove polkit-backend-1 build-dependency

### DIFF
--- a/rpm/polkit-qt-1.spec
+++ b/rpm/polkit-qt-1.spec
@@ -35,7 +35,6 @@ BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  cmake
 BuildRequires:  calligra-extra-cmake-modules
 BuildRequires:  pkgconfig(polkit-gobject-1)
-BuildRequires:  pkgconfig(polkit-backend-1)
 BuildRequires:  pkgconfig(polkit-agent-1)
 BuildRequires:  pkgconfig(gobject-2.0)
 BuildRequires:  pkgconfig(gio-2.0)


### PR DESCRIPTION
This is not needed, and makes builds fail on newer polkit versions.
